### PR TITLE
fix exception message for "categories" error

### DIFF
--- a/aiowallhaven/api.py
+++ b/aiowallhaven/api.py
@@ -90,7 +90,7 @@ class WallHavenAPI(object):
                 case 'people':
                     value |= 0b001
                 case _:
-                    raise ValueError("No valid purity filter found. Only 'sfw', 'sketchy', and 'nsfw' are considered to be valid purity filters.")
+                    raise ValueError("No valid category filter found. Only 'general', 'anime', and 'people' are considered to be valid category filters.")
         result = "{0:03b}".format(value)
         return result
 


### PR DESCRIPTION
When I copied "_translate" function for categories, I changed filter strings, but overlooked the exception messages, so now it's valid. I'm sorry for this, but I discovered it only when wrote some tests for the api ><

Perhaps it makes sense to put all exception messages in separate constant variables to avoid such situations and make code more compact, but *this* is up to you, of course.